### PR TITLE
Feature/petitions auth

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,12 @@ class ApplicationController < ActionController::Base
     false
   end
 
+  def require_current_user
+    if !current_user
+      render(file: File.join(Rails.root, 'views/errors/403.html'), status: 403)
+    end
+  end
+
   protected
 
   def authenticate

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -1,12 +1,11 @@
 require "csv"
 
 class PetitionsController < ApplicationController
+  before_action :require_current_user, only: [:check, :create, :new]
   before_action :redirect_to_valid_state, only: [:index]
   before_action :do_not_cache, except: [:index, :show]
   before_action :set_cors_headers, only: [:index, :show, :count], if: :json_request?
 
-  #before_action :redirect_to_home_page_if_dissolved, only: [:new, :check, :check_results, :create]
-  #before_action :redirect_to_home_page_unless_opened, only: [:index, :new, :check, :check_results, :create]
   before_action :redirect_to_archived_petition_if_archived, only: [:show]
 
   before_action :retrieve_petitions, only: [:index]

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -1,6 +1,6 @@
 class SignaturesController < ApplicationController
   include FormTracking
-
+  before_action :require_current_user, only: [:new, :confirm, :create, :signed, :verify, :thank_you]
   before_action :retrieve_petition, only: [:new, :confirm, :create, :thank_you]
   before_action :retrieve_signature, only: [:verify, :unsubscribe, :signed]
   before_action :build_signature, only: [:new, :confirm, :create]
@@ -228,7 +228,6 @@ class SignaturesController < ApplicationController
 
   def signature_params_for_new
     {
-      location_code: "GB",
       form_token: form_token,
       form_requested_at: form_requested_at
     }
@@ -243,13 +242,12 @@ class SignaturesController < ApplicationController
       ip_address: request.remote_ip,
       form_token: form_token,
       form_requested_at: form_requested_at,
-      image_loaded_at: image_loaded_at,
       name: current_user.username,
       email: current_user.email
     )
   end
 
   def signature_attributes
-    %i[name email email_confirmation postcode location_code uk_citizenship notify_by_email]
+    %i[name email email_confirmation notify_by_email]
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3091,3 +3091,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190514070908'),
 ('20190718133606'),
 ('20200114090018');
+
+

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -1,12 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe PetitionsController, type: :controller do
+  context "Without logged in user" do
+    describe "GET /petitions/new" do
+      it "Should respond with 403" do
+        get :new
+        expect(response).to render_template(file: "403.html.erb")
+        expect(response.status).to be(403)
+      end
+    end
+
+    describe "POST /petitions/new" do
+      it "Should respond with 403" do
+        post :create
+        expect(response).to render_template(file: "403.html.erb")
+        expect(response.status).to be(403)
+      end
+    end
+
+    describe "GET /petitions/check" do
+      it "Should respond with 403" do
+        get :check
+        expect(response).to render_template(file: "403.html.erb")
+        expect(response.status).to be(403)
+      end
+    end
+  end
+
   context "With logged in user" do
 
     let(:user) { FactoryBot.build(:user) }
 
     before { allow(controller).to receive(:current_user).and_return(user) }
-    
+
     describe "GET /petitions/new" do
       it "should assign a petition creator" do
         get :new

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -1,440 +1,267 @@
 require 'rails_helper'
 
 RSpec.describe PetitionsController, type: :controller do
-  describe "GET /petitions/new" do
-    it "should assign a petition creator" do
-      get :new
-      expect(assigns[:new_petition]).not_to be_nil
-    end
+  context "With logged in user" do
 
-    it "is on stage 'petition'" do
-      get :new
-      expect(assigns[:new_petition].stage).to eq "petition";
-    end
+    let(:user) { FactoryBot.build(:user) }
 
-    it "fills in the action if given as query parameter 'q'" do
-      get :new, params: { q: "my fancy new action" }
-      expect(assigns[:new_petition].action).to eq("my fancy new action")
-    end
-
-    context "when parliament is dissolved" do
-      before do
-        allow(Parliament).to receive(:dissolved?).and_return(true)
-      end
-
-      it "redirects to the home page" do
+    before { allow(controller).to receive(:current_user).and_return(user) }
+    
+    describe "GET /petitions/new" do
+      it "should assign a petition creator" do
         get :new
-        expect(response).to redirect_to("https://petition.parliament.uk/")
-      end
-    end
-
-    context "when parliament has not yet opened" do
-      before do
-        allow(Parliament).to receive(:opened?).and_return(false)
+        expect(assigns[:new_petition]).not_to be_nil
       end
 
-      it "redirects to the home page" do
+      it "is on stage 'petition'" do
         get :new
-        expect(response).to redirect_to("https://petition.parliament.uk/")
+        expect(assigns[:new_petition].stage).to eq "petition";
+      end
+
+      it "fills in the action if given as query parameter 'q'" do
+        get :new, params: { q: "my fancy new action" }
+        expect(assigns[:new_petition].action).to eq("my fancy new action")
       end
     end
-  end
 
-  describe "POST /petitions/new" do
-    let(:params) do
-      {
-        action: "Save the planet",
-        background: "Limit temperature rise at two degrees",
-        additional_details: "Global warming is upon us",
-        name: "John Mcenroe", email: "john@example.com",
-        postcode: "SE3 4LL", location_code: "GB",
-        uk_citizenship: "1"
-      }
-    end
-
-    let(:constituency) do
-      FactoryBot.create(:constituency, external_id: "54321", name: "North Creatorshire")
-    end
-
-    before do
-      allow(Constituency).to receive(:find_by_postcode).with("SE34LL").and_return(constituency)
-    end
-
-    context "valid post" do
-      let(:petition) { Petition.find_by_action("Save the planet") }
-
-      it "should successfully create a new petition and a signature" do
-        perform_enqueued_jobs do
-          post :create, params: { stage: "replay_email", petition_creator: params }
-        end
-
-        expect(petition.creator).not_to be_nil
-        expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{petition.id}/thank-you")
+    describe "POST /petitions/new" do
+      let(:params) do
+        {
+          action: "Save the planet",
+          background: "Limit temperature rise at two degrees",
+          additional_details: "Global warming is upon us",
+          name: "John Mcenroe", email: "john@example.com",
+          postcode: "SE3 4LL", location_code: "GB",
+          uk_citizenship: "1"
+        }
       end
 
-      it "should successfully create a new petition and a signature even when email has white space either end" do
-        perform_enqueued_jobs do
-          post :create, params: { stage: "replay_email", petition_creator: params.merge(email: " john@example.com ") }
-        end
+      context "valid post" do
+        let(:petition) { Petition.find_by_action("Save the planet") }
 
-        expect(petition).not_to be_nil
-        expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{petition.id}/thank-you")
-      end
-
-      it "should strip a petition action on petition creation" do
-        perform_enqueued_jobs do
-          post :create, params: { stage: "replay_email", petition_creator: params.merge(action: " Save the planet") }
-        end
-
-        expect(petition).not_to be_nil
-        expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{petition.id}/thank-you")
-      end
-
-      it "should send gather sponsors email to petition's creator" do
-        perform_enqueued_jobs do
-          post :create, params: { stage: "replay_email", petition_creator: params }
-        end
-
-        expect(last_email_sent).to deliver_to("john@example.com")
-        expect(last_email_sent).to deliver_from(%{"Petitions: UK Government and Parliament" <no-reply@petition.parliament.uk>})
-        expect(last_email_sent).to have_subject("Action required: Petition “Save the planet”")
-      end
-
-      it "should successfully point the signature at the petition" do
-        perform_enqueued_jobs do
-          post :create, params: { stage: "replay_email", petition_creator: params }
-        end
-
-        expect(petition.creator.petition).to eq(petition)
-      end
-
-      it "should set user's ip address on signature" do
-        perform_enqueued_jobs do
-          post :create, params: { stage: "replay_email", petition_creator: params }
-        end
-
-        expect(petition.creator.ip_address).to eq("0.0.0.0")
-      end
-
-      it "should not be able to set the state of a new petition" do
-        perform_enqueued_jobs do
-          post :create, params: { stage: "replay_email", petition_creator: params.merge(state: Petition::VALIDATED_STATE) }
-        end
-
-        expect(petition.state).to eq(Petition::PENDING_STATE)
-      end
-
-      it "should not be able to set the state of a new signature" do
-        perform_enqueued_jobs do
-          post :create, params: { stage: "replay_email", petition_creator: params.merge(state: Signature::VALIDATED_STATE) }
-        end
-
-        expect(petition.creator.state).to eq(Signature::PENDING_STATE)
-      end
-
-      it "should set notify_by_email to false on the creator signature" do
-        perform_enqueued_jobs do
-          post :create, params: { stage: "replay_email", petition_creator: params.merge(state: Signature::VALIDATED_STATE) }
-        end
-
-        expect(petition.creator.notify_by_email).to be_falsey
-      end
-
-      it "sets the constituency_id on the creator signature, based on the postcode" do
-        perform_enqueued_jobs do
-          post :create, params: { stage: "replay_email", petition_creator: params.merge(state: Signature::VALIDATED_STATE) }
-        end
-
-        expect(petition.creator.constituency_id).to eq("54321")
-      end
-
-      context "invalid post" do
-        it "should not create a new petition if no action is given" do
+        it "should successfully create a new petition and a signature" do
           perform_enqueued_jobs do
-            post :create, params: { stage: "replay_email", petition_creator: params.merge(action: "") }
+            post :create, params: { stage: "replay_email", petition_creator: params }
           end
 
-          expect(petition).to be_nil
-          expect(assigns[:new_petition].errors[:action]).not_to be_blank
-          expect(response).to be_successful
+          expect(petition.creator).not_to be_nil
+          expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{petition.id}/thank-you")
         end
 
-        it "should not create a new petition if email is invalid" do
+        it "should successfully create a new petition and a signature even when email has white space either end" do
           perform_enqueued_jobs do
-            post :create, params: { stage: "replay_email", petition_creator: params.merge(email: "not much of an email") }
+            post :create, params: { stage: "replay_email", petition_creator: params.merge(email: " john@example.com ") }
           end
 
-          expect(petition).to be_nil
-          expect(response).to be_successful
+          expect(petition).not_to be_nil
+          expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{petition.id}/thank-you")
         end
 
-        it "should not create a new petition if UK citizenship is not confirmed" do
+        it "should strip a petition action on petition creation" do
           perform_enqueued_jobs do
-            post :create, params: { stage: "replay_email", petition_creator: params.merge(uk_citizenship: "0") }
+            post :create, params: { stage: "replay_email", petition_creator: params.merge(action: " Save the planet") }
           end
 
-          expect(petition).to be_nil
-          expect(response).to be_successful
+          expect(petition).not_to be_nil
+          expect(response).to redirect_to("https://petition.parliament.uk/petitions/#{petition.id}/thank-you")
         end
 
-        it "has stage of 'petition' if there is an error on action" do
+        it "should send gather sponsors email to petition's creator" do
           perform_enqueued_jobs do
-            post :create, params: { stage: "replay_email", petition_creator: params.merge(action: "") }
+            post :create, params: { stage: "replay_email", petition_creator: params }
           end
 
-          expect(assigns[:new_petition].stage).to eq "petition"
+          expect(last_email_sent).to deliver_to(user.email)
+          expect(last_email_sent).to deliver_from(%{"Petitions: UK Government and Parliament" <no-reply@petition.parliament.uk>})
+          expect(last_email_sent).to have_subject("Action required: Petition “Save the planet”")
         end
 
-        it "has stage of 'petition' if there is an error on background" do
+        it "should successfully point the signature at the petition" do
           perform_enqueued_jobs do
-            post :create, params: { stage: "replay_email", petition_creator: params.merge(background: "") }
+            post :create, params: { stage: "replay_email", petition_creator: params }
           end
 
-          expect(assigns[:new_petition].stage).to eq "petition"
+          expect(petition.creator.petition).to eq(petition)
         end
 
-        it "has stage of 'petition' if there is an error on additional_details" do
+        it "should set user's ip address on signature" do
           perform_enqueued_jobs do
-            post :create, params: { stage: "replay_email", petition_creator: params.merge(additional_details: "a" * 801) }
+            post :create, params: { stage: "replay_email", petition_creator: params }
           end
 
-          expect(assigns[:new_petition].stage).to eq "petition"
+          expect(petition.creator.ip_address).to eq("0.0.0.0")
         end
 
-        it "has stage of 'creator' if there is an error on name" do
+        it "should not be able to set the state of a new petition" do
           perform_enqueued_jobs do
-            post :create, params: { stage: "replay_email", petition_creator: params.merge(name: "") }
+            post :create, params: { stage: "replay_email", petition_creator: params.merge(state: Petition::VALIDATED_STATE) }
           end
 
-          expect(assigns[:new_petition].stage).to eq "creator"
+          expect(petition.state).to eq(Petition::PENDING_STATE)
         end
 
-        it "has stage of 'creator' if there is an error on uk_citizenship" do
+        it "should not be able to set the state of a new signature" do
           perform_enqueued_jobs do
-            post :create, params: { stage: "replay_email", petition_creator: params.merge(uk_citizenship: "0") }
+            post :create, params: { stage: "replay_email", petition_creator: params.merge(state: Signature::VALIDATED_STATE) }
           end
 
-          expect(assigns[:new_petition].stage).to eq "creator"
+          expect(petition.creator.state).to eq(Signature::PENDING_STATE)
         end
 
-        it "has stage of 'creator' if there is an error on postcode" do
+        it "should set notify_by_email to false on the creator signature" do
           perform_enqueued_jobs do
-            post :create, params: { stage: "replay_email", petition_creator: params.merge(postcode: "") }
+            post :create, params: { stage: "replay_email", petition_creator: params.merge(state: Signature::VALIDATED_STATE) }
           end
 
-          expect(assigns[:new_petition].stage).to eq "creator"
+          expect(petition.creator.notify_by_email).to be_falsey
         end
 
-        it "has stage of 'creator' if there is an error on location_code" do
-          perform_enqueued_jobs do
-            post :create, params: { stage: "replay_email", petition_creator: params.merge(location_code: "") }
+        context "invalid post" do
+          it "should not create a new petition if no action is given" do
+            perform_enqueued_jobs do
+              post :create, params: { stage: "replay_email", petition_creator: params.merge(action: "") }
+            end
+
+            expect(petition).to be_nil
+            expect(assigns[:new_petition].errors[:action]).not_to be_blank
+            expect(response).to be_successful
           end
 
-          expect(assigns[:new_petition].stage).to eq "creator"
-        end
+          it "has stage of 'petition' if there is an error on action" do
+            perform_enqueued_jobs do
+              post :create, params: { stage: "replay_email", petition_creator: params.merge(action: "") }
+            end
 
-        it "has stage of 'replay_email' if there are errors on email and we came from the 'replay_email' stage" do
-          perform_enqueued_jobs do
-            post :create, params: { stage: "replay_email", petition_creator: params.merge(email: "") }
+            expect(assigns[:new_petition].stage).to eq "petition"
           end
 
-          expect(assigns[:new_petition].stage).to eq "replay_email"
-        end
+          it "has stage of 'petition' if there is an error on background" do
+            perform_enqueued_jobs do
+              post :create, params: { stage: "replay_email", petition_creator: params.merge(background: "") }
+            end
 
-        it "has stage of 'creator' if there are errors on email and we came from the 'creator' stage" do
-          perform_enqueued_jobs do
-            post :create, params: { stage: "creator", petition_creator: params.merge(email: "") }
+            expect(assigns[:new_petition].stage).to eq "petition"
           end
 
-          expect(assigns[:new_petition].stage).to eq "creator"
+          it "has stage of 'petition' if there is an error on additional_details" do
+            perform_enqueued_jobs do
+              post :create, params: { stage: "replay_email", petition_creator: params.merge(additional_details: "a" * 801) }
+            end
+
+            expect(assigns[:new_petition].stage).to eq "petition"
+          end
+
         end
       end
     end
 
-    context "when parliament is dissolved" do
-      before do
-        allow(Parliament).to receive(:dissolved?).and_return(true)
-      end
+    describe "GET /petitions/:id" do
+      let(:petition) { double }
 
-      it "redirects to the home page" do
-        post :create, params: { petition: {} }
-        expect(response).to redirect_to("https://petition.parliament.uk/")
-      end
-    end
+      it "assigns the given petition" do
+        allow(petition).to receive(:stopped?).and_return(false)
+        allow(petition).to receive(:collecting_sponsors?).and_return(false)
+        allow(petition).to receive(:in_moderation?).and_return(false)
+        allow(petition).to receive(:moderated?).and_return(true)
+        allow(Petition).to receive_message_chain(:show, find: petition)
 
-    context "when parliament has not yet opened" do
-      before do
-        allow(Parliament).to receive(:opened?).and_return(false)
-      end
-
-      it "redirects to the home page" do
-        post :create, params: { petition: {} }
-        expect(response).to redirect_to("https://petition.parliament.uk/")
-      end
-    end
-  end
-
-  describe "GET /petitions/:id" do
-    let(:petition) { double }
-
-    it "assigns the given petition" do
-      allow(petition).to receive(:stopped?).and_return(false)
-      allow(petition).to receive(:collecting_sponsors?).and_return(false)
-      allow(petition).to receive(:in_moderation?).and_return(false)
-      allow(petition).to receive(:moderated?).and_return(true)
-      allow(Petition).to receive_message_chain(:show, find: petition)
-
-      get :show, params: { id: 1 }
-      expect(assigns(:petition)).to eq(petition)
-    end
-
-    it "does not allow hidden petitions to be shown" do
-      expect {
-        allow(Petition).to receive_message_chain(:visible, :find).and_raise ActiveRecord::RecordNotFound
         get :show, params: { id: 1 }
-      }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(assigns(:petition)).to eq(petition)
+      end
+
+      it "does not allow hidden petitions to be shown" do
+        expect {
+          allow(Petition).to receive_message_chain(:visible, :find).and_raise ActiveRecord::RecordNotFound
+          get :show, params: { id: 1 }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "does not allow stopped petitions to be shown" do
+        allow(petition).to receive(:stopped?).and_return(true)
+        allow(petition).to receive(:collecting_sponsors?).and_return(false)
+        allow(petition).to receive(:in_moderation?).and_return(false)
+        allow(petition).to receive(:moderated?).and_return(false)
+        allow(Petition).to receive_message_chain(:show, find: petition)
+
+        get :show, params: { id: 1 }
+        expect(response).to redirect_to "https://petition.parliament.uk/"
+      end
+
+      context "when the petition is archived" do
+        let!(:petition) { FactoryBot.create(:closed_petition, archived_at: 1.hour.ago) }
+        let!(:archived_petition) { FactoryBot.create(:archived_petition, id: petition.id, parliament: parliament) }
+
+        context "and the parliament is not archived" do
+          let!(:parliament) { FactoryBot.create(:parliament, archived_at: nil) }
+
+          it "assigns the given petition" do
+            get :show, params: { id: petition.id }
+            expect(assigns(:petition)).to eq(petition)
+          end
+        end
+
+        context "and the parliament is archived" do
+          let(:parliament) { FactoryBot.create(:parliament, archived_at: 1.hour.ago) }
+
+          it "redirects to the archived petition page" do
+            get :show, params: { id: petition.id }
+            expect(response).to redirect_to "https://petition.parliament.uk/archived/petitions/#{petition.id}"
+          end
+        end
+      end
     end
 
-    it "does not allow stopped petitions to be shown" do
-      allow(petition).to receive(:stopped?).and_return(true)
-      allow(petition).to receive(:collecting_sponsors?).and_return(false)
-      allow(petition).to receive(:in_moderation?).and_return(false)
-      allow(petition).to receive(:moderated?).and_return(false)
-      allow(Petition).to receive_message_chain(:show, find: petition)
+    describe "GET /petitions" do
+      context "when no state param is provided" do
+        it "is successful" do
+          get :index
+          expect(response).to be_successful
+        end
 
-      get :show, params: { id: 1 }
-      expect(response).to redirect_to "https://petition.parliament.uk/"
-    end
-
-    context "when the petition is archived" do
-      let!(:petition) { FactoryBot.create(:closed_petition, archived_at: 1.hour.ago) }
-      let!(:archived_petition) { FactoryBot.create(:archived_petition, id: petition.id, parliament: parliament) }
-
-      context "and the parliament is not archived" do
-        let!(:parliament) { FactoryBot.create(:parliament, archived_at: nil) }
-
-        it "assigns the given petition" do
-          get :show, params: { id: petition.id }
-          expect(assigns(:petition)).to eq(petition)
+        it "exposes a search scoped to the all facet" do
+          get :index
+          expect(assigns(:petitions).scope).to eq :all
         end
       end
 
-      context "and the parliament is archived" do
-        let(:parliament) { FactoryBot.create(:parliament, archived_at: 1.hour.ago) }
+      context "when a state param is provided" do
+        context "but it is not a public facet from the locale file" do
+          it "redirects to itself with state=all" do
+            get :index, params: { state: "awaiting_monkey" }
+            expect(response).to redirect_to "https://petition.parliament.uk/petitions?state=all"
+          end
 
-        it "redirects to the archived petition page" do
-          get :show, params: { id: petition.id }
-          expect(response).to redirect_to "https://petition.parliament.uk/archived/petitions/#{petition.id}"
+          it "preserves other params when it redirects" do
+            get :index, params: { q: "what is clocks", state: "awaiting_monkey" }
+            expect(response).to redirect_to "https://petition.parliament.uk/petitions?q=what+is+clocks&state=all"
+          end
+        end
+
+        context "and it is a public facet from the locale file" do
+          it "is successful" do
+            get :index, params: { state: "open" }
+            expect(response).to be_successful
+          end
+
+          it "exposes a search scoped to the state param" do
+            get :index, params: { state: "open" }
+            expect(assigns(:petitions).scope).to eq :open
+          end
         end
       end
     end
-  end
 
-  describe "GET /petitions" do
-    context "when no state param is provided" do
+    describe "GET /petitions/check" do
       it "is successful" do
-        get :index
+        get :check
         expect(response).to be_successful
       end
-
-      it "exposes a search scoped to the all facet" do
-        get :index
-        expect(assigns(:petitions).scope).to eq :all
-      end
     end
 
-    context "when a state param is provided" do
-      context "but it is not a public facet from the locale file" do
-        it "redirects to itself with state=all" do
-          get :index, params: { state: "awaiting_monkey" }
-          expect(response).to redirect_to "https://petition.parliament.uk/petitions?state=all"
-        end
-
-        it "preserves other params when it redirects" do
-          get :index, params: { q: "what is clocks", state: "awaiting_monkey" }
-          expect(response).to redirect_to "https://petition.parliament.uk/petitions?q=what+is+clocks&state=all"
-        end
-      end
-
-      context "and it is a public facet from the locale file" do
-        it "is successful" do
-          get :index, params: { state: "open" }
-          expect(response).to be_successful
-        end
-
-        it "exposes a search scoped to the state param" do
-          get :index, params: { state: "open" }
-          expect(assigns(:petitions).scope).to eq :open
-        end
-      end
-    end
-
-    context "when parliament has not yet opened" do
-      before do
-        allow(Parliament).to receive(:opened?).and_return(false)
-      end
-
-      it "redirects to the home page" do
-        get :index
-        expect(response).to redirect_to("https://petition.parliament.uk/")
-      end
-    end
-  end
-
-  describe "GET /petitions/check" do
-    it "is successful" do
-      get :check
-      expect(response).to be_successful
-    end
-
-    context "when parliament is dissolved" do
-      before do
-        allow(Parliament).to receive(:dissolved?).and_return(true)
-      end
-
-      it "redirects to the home page" do
-        get :check
-        expect(response).to redirect_to("https://petition.parliament.uk/")
-      end
-    end
-
-    context "when parliament has not yet opened" do
-      before do
-        allow(Parliament).to receive(:opened?).and_return(false)
-      end
-
-      it "redirects to the home page" do
-        get :check
-        expect(response).to redirect_to("https://petition.parliament.uk/")
-      end
-    end
-  end
-
-  describe "GET /petitions/check_results" do
-    it "is successful" do
-      get :check_results, params: { q: "action" }
-      expect(response).to be_successful
-    end
-
-    context "when parliament is dissolved" do
-      before do
-        allow(Parliament).to receive(:dissolved?).and_return(true)
-      end
-
-      it "redirects to the home page" do
+    describe "GET /petitions/check_results" do
+      it "is successful" do
         get :check_results, params: { q: "action" }
-        expect(response).to redirect_to("https://petition.parliament.uk/")
-      end
-    end
-
-    context "when parliament has not yet opened" do
-      before do
-        allow(Parliament).to receive(:opened?).and_return(false)
-      end
-
-      it "redirects to the home page" do
-        get :check_results, params: { q: "action" }
-        expect(response).to redirect_to("https://petition.parliament.uk/")
+        expect(response).to be_successful
       end
     end
   end

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -1,37 +1,141 @@
 require 'rails_helper'
 
 RSpec.describe SignaturesController, type: :controller do
-  before do
-    constituency = FactoryBot.create(:constituency, :london_and_westminster)
-    allow(Constituency).to receive(:find_by_postcode).with("SW1A1AA").and_return(constituency)
-  end
+  context "Without logged in user" do
 
-  describe "GET /petitions/:petition_id/signatures/new" do
-    context "when the petition doesn't exist" do
-      it "raises an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :new, params: { petition_id: 1 }
-        }.to raise_exception(ActiveRecord::RecordNotFound)
+    let(:petition) { FactoryBot.create(:open_petition) }
+
+    describe "GET /petitions/:petition_id/signatures/new" do
+      it 'Should respond with 403' do
+        get :new, params: { petition_id: petition.id }
+        expect(response).to render_template(file: "403.html.erb")
+        expect(response.status).to be(403)
       end
     end
 
-    %w[pending validated sponsored flagged hidden stopped].each do |state|
-      context "when the petition is #{state}" do
-        let(:petition) { FactoryBot.create(:"#{state}_petition") }
+    describe "POST /petitions/:petition_id/signatures/new" do
+      it "Should respond with 403" do
+        post :confirm, params: { petition_id: petition.id }
+        expect(response).to render_template(file: "403.html.erb")
+        expect(response.status).to be(403)
+      end
+    end
 
+    describe "POST /petitions/:petition_id/signatures" do
+      it "Should respond with 403" do
+        post :create, params: { petition_id: petition.id }
+        expect(response).to render_template(file: "403.html.erb")
+        expect(response.status).to be(403)
+      end
+    end
+
+    describe "GET /petitions/:petition_id/signatures/thank-you" do
+      it "Should respond with 403" do
+        get :thank_you, params: { petition_id: petition.id }
+        expect(response).to render_template(file: "403.html.erb")
+        expect(response.status).to be(403)
+      end
+    end
+
+    describe "GET /signatures/:id/verify" do
+      it "Should respond with 403" do
+        get :verify, params: { id: 1 }
+        expect(response).to render_template(file: "403.html.erb")
+        expect(response.status).to be(403)
+      end
+    end
+
+    describe "GET /signatures/:id/signed" do
+      it "Should respond with 403" do
+        get :signed, params: { id: 1 }
+        expect(response).to render_template(file: "403.html.erb")
+        expect(response.status).to be(403)
+      end
+    end
+
+    describe "GET /signatures/:id/unsubscribe" do
+      it "Should respond with 403" do
+        get :signed, params: { id: 1 }
+        expect(response).to render_template(file: "403.html.erb")
+        expect(response.status).to be(403)
+      end
+    end
+  end
+
+  context "With logged in user" do
+
+    let(:user) { FactoryBot.build(:user) }
+    before { allow(controller).to receive(:current_user).and_return(user) }
+
+    before do
+      constituency = FactoryBot.create(:constituency, :london_and_westminster)
+      allow(Constituency).to receive(:find_by_postcode).with("SW1A1AA").and_return(constituency)
+    end
+
+    describe "GET /petitions/:petition_id/signatures/new" do
+      context "when the petition doesn't exist" do
         it "raises an ActiveRecord::RecordNotFound exception" do
           expect {
-            get :new, params: { petition_id: petition.id }
+            get :new, params: { petition_id: 1 }
           }.to raise_exception(ActiveRecord::RecordNotFound)
         end
       end
-    end
 
-    %w[closed rejected].each do |state|
-      context "when the petition is #{state}" do
-        let(:petition) { FactoryBot.create(:"#{state}_petition") }
+      %w[pending validated sponsored flagged hidden stopped].each do |state|
+        context "when the petition is #{state}" do
+          let(:petition) { FactoryBot.create(:"#{state}_petition") }
+
+          it "raises an ActiveRecord::RecordNotFound exception" do
+            expect {
+              get :new, params: { petition_id: petition.id }
+            }.to raise_exception(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+
+      %w[closed rejected].each do |state|
+        context "when the petition is #{state}" do
+          let(:petition) { FactoryBot.create(:"#{state}_petition") }
+
+          before do
+            get :new, params: { petition_id: petition.id }
+          end
+
+          it "assigns the @petition instance variable" do
+            expect(assigns[:petition]).to eq(petition)
+          end
+
+          it "redirects to the petition page" do
+            expect(response).to redirect_to("/petitions/#{petition.id}")
+          end
+        end
+      end
+
+      context "when the petition is open" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:current_time) { Time.utc(2019, 4, 18, 6, 0, 0) }
+
+        around do |example|
+          travel_to(current_time) { example.run }
+        end
 
         before do
+          allow(Authlogic::Random).to receive(:friendly_token).and_return("D8MxrkwNexP1NgxpZqaa")
+
+          session[:form_requests] = {
+            "100000" => {
+              "form_token" => "jcr0DcYQXio18qKDBGwa",
+              "form_requested_at" => "2019-04-16T06:00:00Z"
+            },
+            "100001" => {
+              "form_token" => "G0WnZSxal6vmZkFYnzYa",
+              "form_requested_at" => "2019-04-18T04:00:00Z"
+            }
+          }
+
+          cookies.encrypted["jcr0DcYQXio18qKDBGwa"] = "2019-04-16T06:00:00Z"
+          cookies.encrypted["G0WnZSxal6vmZkFYnzYa"] = "2019-04-18T04:00:00Z"
+
           get :new, params: { petition_id: petition.id }
         end
 
@@ -39,191 +143,38 @@ RSpec.describe SignaturesController, type: :controller do
           expect(assigns[:petition]).to eq(petition)
         end
 
-        it "redirects to the petition page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}")
-        end
-      end
-    end
-
-    context "when the petition is open" do
-      let(:petition) { FactoryBot.create(:open_petition) }
-      let(:current_time) { Time.utc(2019, 4, 18, 6, 0, 0) }
-
-      around do |example|
-        travel_to(current_time) { example.run }
-      end
-
-      before do
-        allow(Authlogic::Random).to receive(:friendly_token).and_return("D8MxrkwNexP1NgxpZqaa")
-
-        session[:form_requests] = {
-          "100000" => {
-            "form_token" => "jcr0DcYQXio18qKDBGwa",
-            "form_requested_at" => "2019-04-16T06:00:00Z"
-          },
-          "100001" => {
-            "form_token" => "G0WnZSxal6vmZkFYnzYa",
-            "form_requested_at" => "2019-04-18T04:00:00Z"
-          }
-        }
-
-        cookies.encrypted["jcr0DcYQXio18qKDBGwa"] = "2019-04-16T06:00:00Z"
-        cookies.encrypted["G0WnZSxal6vmZkFYnzYa"] = "2019-04-18T04:00:00Z"
-
-        get :new, params: { petition_id: petition.id }
-      end
-
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
-      end
-
-      it "assigns the @signature instance variable with a new signature" do
-        expect(assigns[:signature]).not_to be_persisted
-      end
-
-      it "sets the signature's location_code to 'GB'" do
-        expect(assigns[:signature].location_code).to eq("GB")
-      end
-
-      it "sets the form token and requested at details in the session" do
-        expect(session[:form_requests]).to match(a_hash_including(
-          "#{petition.id}" => {
-            "form_token" => "D8MxrkwNexP1NgxpZqaa",
-            "form_requested_at" => "2019-04-18T06:00:00Z"
-          }
-        ))
-      end
-
-      it "sets the signature's form token to the one in the session" do
-        expect(assigns[:signature].form_token).to eq("D8MxrkwNexP1NgxpZqaa")
-      end
-
-      it "sets the signature's form requested at timestamp to the one in the session" do
-        expect(assigns[:signature].form_requested_at).to eq("2019-04-18T06:00:00Z".in_time_zone)
-      end
-
-      it "expires old form requests" do
-        expect(session[:form_requests]["100000"]).to be_nil
-        expect(response.cookies).to have_key("jcr0DcYQXio18qKDBGwa")
-        expect(response.cookies["jcr0DcYQXio18qKDBGwa"]).to be_nil
-      end
-
-      it "leaves current form request untouched" do
-        expect(session[:form_requests]["100001"]["form_token"]).to eq("G0WnZSxal6vmZkFYnzYa")
-        expect(session[:form_requests]["100001"]["form_requested_at"]).to eq("2019-04-18T04:00:00Z")
-        expect(cookies.encrypted["G0WnZSxal6vmZkFYnzYa"]).to eq("2019-04-18T04:00:00Z")
-        expect(response.cookies).not_to have_key("G0WnZSxal6vmZkFYnzYa")
-      end
-
-      it "renders the signatures/new template" do
-        expect(response).to render_template("signatures/new")
-      end
-    end
-  end
-
-  describe "POST /petitions/:petition_id/signatures/new" do
-    let(:params) do
-      {
-        name: "Ted Berry",
-        email: "ted@example.com",
-        uk_citizenship: "1",
-        postcode: "SW1A 1AA",
-        location_code: "GB"
-      }
-    end
-
-    context "when the petition doesn't exist" do
-      it "raises an ActiveRecord::RecordNotFound exception" do
-        expect {
-          post :confirm, params: { petition_id: 1, signature: params }
-        }.to raise_exception(ActiveRecord::RecordNotFound)
-      end
-    end
-
-    %w[pending validated sponsored flagged hidden stopped].each do |state|
-      context "when the petition is #{state}" do
-        let(:petition) { FactoryBot.create(:"#{state}_petition") }
-
-        it "raises an ActiveRecord::RecordNotFound exception" do
-          expect {
-            post :confirm, params: { petition_id: petition.id, signature: params }
-          }.to raise_exception(ActiveRecord::RecordNotFound)
-        end
-      end
-    end
-
-    %w[closed rejected].each do |state|
-      context "when the petition is #{state}" do
-        let(:petition) { FactoryBot.create(:"#{state}_petition") }
-
-        before do
-          post :confirm, params: { petition_id: petition.id, signature: params }
+        it "assigns the @signature instance variable with a new signature" do
+          expect(assigns[:signature]).not_to be_persisted
         end
 
-        it "assigns the @petition instance variable" do
-          expect(assigns[:petition]).to eq(petition)
+        it "sets the form token and requested at details in the session" do
+          expect(session[:form_requests]).to match(a_hash_including(
+            "#{petition.id}" => {
+              "form_token" => "D8MxrkwNexP1NgxpZqaa",
+              "form_requested_at" => "2019-04-18T06:00:00Z"
+            }
+          ))
         end
 
-        it "redirects to the petition page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}")
+        it "sets the signature's form token to the one in the session" do
+          expect(assigns[:signature].form_token).to eq("D8MxrkwNexP1NgxpZqaa")
         end
-      end
-    end
 
-    context "when the petition is open" do
-      let(:petition) { FactoryBot.create(:open_petition) }
-      let(:current_time) { Time.utc(2019, 4, 18, 6, 0, 30) }
+        it "sets the signature's form requested at timestamp to the one in the session" do
+          expect(assigns[:signature].form_requested_at).to eq("2019-04-18T06:00:00Z".in_time_zone)
+        end
 
-      around do |example|
-        travel_to(current_time) { example.run }
-      end
+        it "expires old form requests" do
+          expect(session[:form_requests]["100000"]).to be_nil
+          expect(response.cookies).to have_key("jcr0DcYQXio18qKDBGwa")
+          expect(response.cookies["jcr0DcYQXio18qKDBGwa"]).to be_nil
+        end
 
-      before do
-        session[:form_requests] = {
-          "#{petition.id}" => {
-            "form_token" => "wYonHKjTeW7mtTusqDva",
-            "form_requested_at" => "2019-04-18T06:00:00Z"
-          }
-        }
-
-        post :confirm, params: { petition_id: petition.id, signature: params }
-      end
-
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
-      end
-
-      it "assigns the @signature instance variable with a new signature" do
-        expect(assigns[:signature]).not_to be_persisted
-      end
-
-      it "sets the signature's params" do
-        expect(assigns[:signature].name).to eq("Ted Berry")
-        expect(assigns[:signature].email).to eq("ted@example.com")
-        expect(assigns[:signature].uk_citizenship).to eq("1")
-        expect(assigns[:signature].postcode).to eq("SW1A1AA")
-        expect(assigns[:signature].location_code).to eq("GB")
-        expect(assigns[:signature].form_token).to eq("wYonHKjTeW7mtTusqDva")
-        expect(assigns[:signature].form_requested_at).to eq("2019-04-18T06:00:00Z".in_time_zone)
-      end
-
-      it "records the IP address on the signature" do
-        expect(assigns[:signature].ip_address).to eq("0.0.0.0")
-      end
-
-      it "renders the signatures/confirm template" do
-        expect(response).to render_template("signatures/confirm")
-      end
-
-      context "and the params are invalid" do
-        let(:params) do
-          {
-            name: "Ted Berry",
-            email: "",
-            uk_citizenship: "1",
-            postcode: "12345",
-            location_code: "GB"
-          }
+        it "leaves current form request untouched" do
+          expect(session[:form_requests]["100001"]["form_token"]).to eq("G0WnZSxal6vmZkFYnzYa")
+          expect(session[:form_requests]["100001"]["form_requested_at"]).to eq("2019-04-18T04:00:00Z")
+          expect(cookies.encrypted["G0WnZSxal6vmZkFYnzYa"]).to eq("2019-04-18T04:00:00Z")
+          expect(response.cookies).not_to have_key("G0WnZSxal6vmZkFYnzYa")
         end
 
         it "renders the signatures/new template" do
@@ -231,45 +182,679 @@ RSpec.describe SignaturesController, type: :controller do
         end
       end
     end
-  end
 
-  describe "POST /petitions/:petition_id/signatures" do
-    let(:params) do
-      {
-        name: "Ted Berry",
-        email: "ted@example.com",
-        uk_citizenship: "1",
-        postcode: "SW1A 1AA",
-        location_code: "GB"
-      }
-    end
-
-    context "when the petition doesn't exist" do
-      it "raises an ActiveRecord::RecordNotFound exception" do
-        expect {
-          post :create, params: { petition_id: 1, signature: params }
-        }.to raise_exception(ActiveRecord::RecordNotFound)
+    describe "POST /petitions/:petition_id/signatures/new" do
+      let(:params) do
+        {
+          name: "Ted Berry",
+          email: "ted@example.com"
+        }
       end
-    end
 
-    %w[pending validated sponsored flagged hidden stopped].each do |state|
-      context "when the petition is #{state}" do
-        let(:petition) { FactoryBot.create(:"#{state}_petition") }
-
+      context "when the petition doesn't exist" do
         it "raises an ActiveRecord::RecordNotFound exception" do
           expect {
-            post :create, params: { petition_id: petition.id, signature: params }
+            post :confirm, params: { petition_id: 1, signature: params }
           }.to raise_exception(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      %w[pending validated sponsored flagged hidden stopped].each do |state|
+        context "when the petition is #{state}" do
+          let(:petition) { FactoryBot.create(:"#{state}_petition") }
+
+          it "raises an ActiveRecord::RecordNotFound exception" do
+            expect {
+              post :confirm, params: { petition_id: petition.id, signature: params }
+            }.to raise_exception(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+
+      %w[closed rejected].each do |state|
+        context "when the petition is #{state}" do
+          let(:petition) { FactoryBot.create(:"#{state}_petition") }
+
+          before do
+            post :confirm, params: { petition_id: petition.id, signature: params }
+          end
+
+          it "assigns the @petition instance variable" do
+            expect(assigns[:petition]).to eq(petition)
+          end
+
+          it "redirects to the petition page" do
+            expect(response).to redirect_to("/petitions/#{petition.id}")
+          end
+        end
+      end
+
+      context "when the petition is open" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:current_time) { Time.utc(2019, 4, 18, 6, 0, 30) }
+
+        around do |example|
+          travel_to(current_time) { example.run }
+        end
+
+        before do
+          session[:form_requests] = {
+            "#{petition.id}" => {
+              "form_token" => "wYonHKjTeW7mtTusqDva",
+              "form_requested_at" => "2019-04-18T06:00:00Z"
+            }
+          }
+
+          post :confirm, params: { petition_id: petition.id, signature: params }
+        end
+
+        it "assigns the @petition instance variable" do
+          expect(assigns[:petition]).to eq(petition)
+        end
+
+        it "assigns the @signature instance variable with a new signature" do
+          expect(assigns[:signature]).not_to be_persisted
+        end
+
+        it "sets the signature's params" do
+          expect(assigns[:signature].name).to eq(user.username)
+          expect(assigns[:signature].email).to eq(user.email)
+          expect(assigns[:signature].form_token).to eq("wYonHKjTeW7mtTusqDva")
+          expect(assigns[:signature].form_requested_at).to eq("2019-04-18T06:00:00Z".in_time_zone)
+        end
+
+        it "records the IP address on the signature" do
+          expect(assigns[:signature].ip_address).to eq("0.0.0.0")
+        end
+
+        it "renders the signatures/confirm template" do
+          expect(response).to render_template("signatures/confirm")
         end
       end
     end
 
-    %w[closed rejected].each do |state|
-      context "when the petition is #{state}" do
-        let(:petition) { FactoryBot.create(:"#{state}_petition") }
+    describe "POST /petitions/:petition_id/signatures" do
+      let(:params) do
+        {
+          name: "Ted Berry",
+          email: "ted@example.com"
+        }
+      end
+
+      context "when the petition doesn't exist" do
+        it "raises an ActiveRecord::RecordNotFound exception" do
+          expect {
+            post :create, params: { petition_id: 1, signature: params }
+          }.to raise_exception(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      %w[pending validated sponsored flagged hidden stopped].each do |state|
+        context "when the petition is #{state}" do
+          let(:petition) { FactoryBot.create(:"#{state}_petition") }
+
+          it "raises an ActiveRecord::RecordNotFound exception" do
+            expect {
+              post :create, params: { petition_id: petition.id, signature: params }
+            }.to raise_exception(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+
+      %w[closed rejected].each do |state|
+        context "when the petition is #{state}" do
+          let(:petition) { FactoryBot.create(:"#{state}_petition") }
+
+          before do
+            post :create, params: { petition_id: petition.id, signature: params }
+          end
+
+          it "assigns the @petition instance variable" do
+            expect(assigns[:petition]).to eq(petition)
+          end
+
+          it "redirects to the petition page" do
+            expect(response).to redirect_to("/petitions/#{petition.id}")
+          end
+        end
+      end
+
+      context "when the petition is open" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:current_time) { Time.utc(2019, 4, 18, 6, 1, 0) }
+
+        around do |example|
+          travel_to(current_time) { example.run }
+        end
+
+        context "and the signature is not a duplicate" do
+          before do
+            cookies.encrypted["wYonHKjTeW7mtTusqDva"] = "2019-04-18T06:00:00Z"
+
+            session[:form_requests] = {
+              "#{petition.id}" => {
+                "form_token" => "wYonHKjTeW7mtTusqDva",
+                "form_requested_at" => "2019-04-18T06:00:00Z"
+              }
+            }
+
+            perform_enqueued_jobs {
+              post :create, params: { petition_id: petition.id, signature: params }
+            }
+          end
+
+          it "assigns the @petition instance variable" do
+            expect(assigns[:petition]).to eq(petition)
+          end
+
+          it "assigns the @signature instance variable with a saved signature" do
+            expect(assigns[:signature]).to be_persisted
+          end
+
+          it "sets the signature's params" do
+            expect(assigns[:signature].name).to eq(user.username)
+            expect(assigns[:signature].email).to eq(user.email)
+            expect(assigns[:signature].form_token).to eq("wYonHKjTeW7mtTusqDva")
+            expect(assigns[:signature].form_requested_at).to eq("2019-04-18T06:00:00Z".in_time_zone)
+          end
+
+          it "records the IP address on the signature" do
+            expect(assigns[:signature].ip_address).to eq("0.0.0.0")
+          end
+
+          it "sends a confirmation email" do
+            expect(last_email_sent).to deliver_to(user.email)
+            expect(last_email_sent).to have_subject("Please confirm your email address")
+          end
+
+          it "redirects to the thank you page" do
+            expect(response).to redirect_to("/petitions/#{petition.id}/signatures/thank-you")
+          end
+
+          it "deletes the form request details" do
+            expect(response.cookies).to have_key("wYonHKjTeW7mtTusqDva")
+            expect(response.cookies["wYonHKjTeW7mtTusqDva"]).to be_nil
+            expect(session[:form_requests]["#{petition.id}"]).to be_nil
+          end
+        end
+
+        context "and the signature is a pending duplicate" do
+          let!(:signature) { FactoryBot.create(:pending_signature, params.merge(petition: petition, email: user.email)) }
+
+          before do
+            perform_enqueued_jobs {
+              post :create, params: { petition_id: petition.id, signature: params.merge(email: user.email) }
+            }
+          end
+
+          it "assigns the @petition instance variable" do
+            expect(assigns[:petition]).to eq(petition)
+          end
+
+          it "assigns the @signature instance variable to the original signature" do
+            expect(assigns[:signature]).to eq(signature)
+          end
+
+          it "re-sends the confirmation email" do
+            expect(last_email_sent).to deliver_to(user.email)
+            expect(last_email_sent).to have_subject("Please confirm your email address")
+          end
+
+          it "redirects to the thank you page" do
+            expect(response).to redirect_to("/petitions/#{petition.id}/signatures/thank-you")
+          end
+        end
+
+        context "and the signature is a pending duplicate alias" do
+          let!(:signature) { FactoryBot.create(:pending_signature, params.merge(petition: petition, name: user.username, email: user.email)) }
+
+          before do
+            allow(Site).to receive(:disable_plus_address_check?).and_return(true)
+
+            perform_enqueued_jobs {
+              post :create, params: { petition_id: petition.id, signature: params.merge(email: user.email) }
+            }
+          end
+
+          it "assigns the @petition instance variable" do
+            expect(assigns[:petition]).to eq(petition)
+          end
+
+          it "assigns the @signature instance variable to the original signature" do
+            expect(assigns[:signature]).to eq(signature)
+          end
+
+          it "re-sends the confirmation email" do
+            expect(last_email_sent).to deliver_to(user.email)
+            expect(last_email_sent).to have_subject("Please confirm your email address")
+          end
+
+          it "redirects to the thank you page" do
+            expect(response).to redirect_to("/petitions/#{petition.id}/signatures/thank-you")
+          end
+        end
+
+        context "and the signature is a validated duplicate" do
+          let!(:signature) { FactoryBot.create(:validated_signature, params.merge(petition: petition, email: user.email)) }
+
+          before do
+            perform_enqueued_jobs {
+              post :create, params: { petition_id: petition.id, signature: params.merge!(email: user.email) }
+            }
+          end
+
+          it "assigns the @petition instance variable" do
+            expect(assigns[:petition]).to eq(petition)
+          end
+
+          it "assigns the @signature instance variable to the original signature" do
+            expect(assigns[:signature]).to eq(signature)
+          end
+
+          it "sends a duplicate signature email" do
+            expect(last_email_sent).to deliver_to(user.email)
+            expect(last_email_sent).to have_subject("Duplicate signature of petition")
+          end
+
+          it "redirects to the thank you page" do
+            expect(response).to redirect_to("/petitions/#{petition.id}/signatures/thank-you")
+          end
+        end
+
+        context "and the signature is a validated duplicate alias" do
+          let!(:signature) { FactoryBot.create(:validated_signature, params.merge(petition: petition, email: user.email)) }
+
+          before do
+            allow(Site).to receive(:disable_plus_address_check?).and_return(true)
+
+            perform_enqueued_jobs {
+              post :create, params: { petition_id: petition.id, signature: params.merge(email: user.email) }
+            }
+          end
+
+          it "assigns the @petition instance variable" do
+            expect(assigns[:petition]).to eq(petition)
+          end
+
+          it "assigns the @signature instance variable to the original signature" do
+            expect(assigns[:signature]).to eq(signature)
+          end
+
+          it "sends a duplicate signature email" do
+            expect(last_email_sent).to deliver_to(user.email)
+            expect(last_email_sent).to have_subject("Duplicate signature of petition")
+          end
+
+          it "redirects to the thank you page" do
+            expect(response).to redirect_to("/petitions/#{petition.id}/signatures/thank-you")
+          end
+        end
+      end
+    end
+
+    describe "GET /petitions/:petition_id/signatures/thank-you" do
+      context "when the petition doesn't exist" do
+        it "raises an ActiveRecord::RecordNotFound exception" do
+          expect {
+            get :thank_you, params: { petition_id: 1 }
+          }.to raise_exception(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      %w[pending validated sponsored flagged hidden stopped].each do |state|
+        context "when the petition is #{state}" do
+          let(:petition) { FactoryBot.create(:"#{state}_petition") }
+
+          it "raises an ActiveRecord::RecordNotFound exception" do
+            expect {
+              get :thank_you, params: { petition_id: petition.id }
+            }.to raise_exception(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+
+      context "when the petition was rejected" do
+        let(:petition) { FactoryBot.create(:rejected_petition) }
 
         before do
-          post :create, params: { petition_id: petition.id, signature: params }
+          get :thank_you, params: { petition_id: petition.id }
+        end
+
+        it "assigns the @petition instance variable" do
+          expect(assigns[:petition]).to eq(petition)
+        end
+
+        it "sets the flash :notice message" do
+          expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been rejected")
+        end
+
+        it "redirects to the petition page" do
+          expect(response).to redirect_to("/petitions/#{petition.id}")
+        end
+      end
+
+      context "when the petition was closed more than 24 hours ago" do
+        let(:petition) { FactoryBot.create(:closed_petition, closed_at: 36.hours.ago) }
+        let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
+
+        before do
+          get :thank_you, params: { petition_id: petition.id }
+        end
+
+        it "assigns the @petition instance variable" do
+          expect(assigns[:petition]).to eq(petition)
+        end
+
+        it "sets the flash :notice message" do
+          expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+        end
+
+        it "redirects to the petition page" do
+          expect(response).to redirect_to("/petitions/#{petition.id}")
+        end
+      end
+
+      context "when the petition was closed less than 24 hours ago" do
+        let(:petition) { FactoryBot.create(:closed_petition, closed_at: 12.hours.ago) }
+        let(:signature) { FactoryBot.create(:validated_signature, :just_signed, petition: petition) }
+
+        before do
+          get :thank_you, params: { petition_id: petition.id }
+        end
+
+        it "assigns the @petition instance variable" do
+          expect(assigns[:petition]).to eq(petition)
+        end
+
+        it "sets the flash :notice message" do
+          expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+        end
+
+        it "redirects to the petition page" do
+          expect(response).to redirect_to("/petitions/#{petition.id}")
+        end
+      end
+
+      context "when the petition is open" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:signature) { FactoryBot.create(:validated_signature, :just_signed, petition: petition) }
+
+        before do
+          get :thank_you, params: { petition_id: petition.id }
+        end
+
+        it "assigns the @petition instance variable" do
+          expect(assigns[:petition]).to eq(petition)
+        end
+
+        it "renders the signatures/thank_you template" do
+          expect(response).to render_template("signatures/thank_you")
+        end
+      end
+    end
+
+    describe "GET /signatures/:id/verify" do
+      context "when the signature doesn't exist" do
+        it "raises an ActiveRecord::RecordNotFound exception" do
+          expect {
+            get :verify, params: { id: 1, token: "token" }
+          }.to raise_exception(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context "when the signature token is invalid" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+
+        it "raises an ActiveRecord::RecordNotFound exception" do
+          expect {
+            get :verify, params: { id: signature.id, token: "token" }
+          }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context "when the signature is fraudulent" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:signature) { FactoryBot.create(:fraudulent_signature, petition: petition) }
+
+        it "doesn't raise an ActiveRecord::RecordNotFound exception" do
+          expect {
+            get :verify, params: { id: signature.id, token: signature.perishable_token }
+          }.not_to raise_error
+        end
+      end
+
+      context "when the signature is invalidated" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:signature) { FactoryBot.create(:invalidated_signature, petition: petition) }
+
+        it "doesn't raise an ActiveRecord::RecordNotFound exception" do
+          expect {
+            get :verify, params: { id: signature.id, token: signature.perishable_token }
+          }.not_to raise_error
+        end
+      end
+
+      %w[pending validated sponsored flagged hidden stopped].each do |state|
+        context "when the petition is #{state}" do
+          let(:petition) { FactoryBot.create(:"#{state}_petition") }
+          let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+
+          it "raises an ActiveRecord::RecordNotFound exception" do
+            expect {
+              get :verify, params: { id: signature.id, token: signature.perishable_token }
+            }.to raise_exception(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+
+      context "when the petition was rejected" do
+        let(:petition) { FactoryBot.create(:rejected_petition) }
+        let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+
+        before do
+          get :verify, params: { id: signature.id, token: signature.perishable_token }
+        end
+
+        it "assigns the @signature instance variable" do
+          expect(assigns[:signature]).to eq(signature)
+        end
+
+        it "assigns the @petition instance variable" do
+          expect(assigns[:petition]).to eq(petition)
+        end
+
+        it "sets the flash :notice message" do
+          expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been rejected")
+        end
+
+        it "redirects to the petition page" do
+          expect(response).to redirect_to("/petitions/#{petition.id}")
+        end
+      end
+
+      context "when the petition was closed more than 24 hours ago" do
+        let(:petition) { FactoryBot.create(:closed_petition, closed_at: 36.hours.ago) }
+        let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+
+        before do
+          get :verify, params: { id: signature.id, token: signature.perishable_token }
+        end
+
+        it "assigns the @signature instance variable" do
+          expect(assigns[:signature]).to eq(signature)
+        end
+
+        it "assigns the @petition instance variable" do
+          expect(assigns[:petition]).to eq(petition)
+        end
+
+        it "sets the flash :notice message" do
+          expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+        end
+
+        it "redirects to the petition page" do
+          expect(response).to redirect_to("/petitions/#{petition.id}")
+        end
+      end
+
+      context "when the petition was closed less than 24 hours ago" do
+        let(:petition) { FactoryBot.create(:closed_petition, closed_at: 12.hours.ago) }
+        let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+
+        before do
+          get :verify, params: { id: signature.id, token: signature.perishable_token }
+        end
+
+        it "assigns the @signature instance variable" do
+          expect(assigns[:signature]).to eq(signature)
+        end
+
+        it "assigns the @petition instance variable" do
+          expect(assigns[:petition]).to eq(petition)
+        end
+
+        it "validates the signature" do
+          expect(assigns[:signature]).to be_validated
+        end
+
+        it "records the constituency id on the signature" do
+          expect(assigns[:signature].constituency_id).to eq("3415")
+        end
+
+        it "records the ip address on the signature" do
+          expect(assigns[:signature].validated_ip).to eq("0.0.0.0")
+        end
+
+        it "saves the signed token in the session" do
+          expect(session[:signed_tokens]).to eq({ signature.id.to_s => signature.signed_token })
+        end
+
+        it "redirects to the signed signature page" do
+          expect(response).to redirect_to("/signatures/#{signature.id}/signed")
+        end
+      end
+
+      context "when the petition is open" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+        let(:other_petition) { FactoryBot.create(:open_petition) }
+        let(:other_signature) { FactoryBot.create(:validated_signature, petition: other_petition) }
+
+        before do
+          session[:signed_tokens] = {
+            other_signature.id.to_s => other_signature.signed_token
+          }
+
+          get :verify, params: { id: signature.id, token: signature.perishable_token }
+        end
+
+        it "assigns the @signature instance variable" do
+          expect(assigns[:signature]).to eq(signature)
+        end
+
+        it "assigns the @petition instance variable" do
+          expect(assigns[:petition]).to eq(petition)
+        end
+
+        it "validates the signature" do
+          expect(assigns[:signature]).to be_validated
+        end
+
+        it "records the constituency id on the signature" do
+          expect(assigns[:signature].constituency_id).to eq("3415")
+        end
+
+        it "records the ip address on the signature" do
+          expect(assigns[:signature].validated_ip).to eq("0.0.0.0")
+        end
+
+        it "deletes old signed tokens" do
+          expect(session[:signed_tokens]).not_to have_key(other_signature.id.to_s)
+        end
+
+        it "saves the signed token in the session" do
+          expect(session[:signed_tokens]).to eq({ signature.id.to_s => signature.signed_token })
+        end
+
+        it "redirects to the signed signature page" do
+          expect(response).to redirect_to("/signatures/#{signature.id}/signed")
+        end
+
+        context "and the signature has already been validated" do
+          let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
+
+          it "doesn't set the flash :notice message" do
+            expect(flash[:notice]).to be_nil
+          end
+        end
+      end
+    end
+
+    describe "GET /signatures/:id/signed" do
+      context "when the signature doesn't exist" do
+        it "raises an ActiveRecord::RecordNotFound exception" do
+          expect {
+            get :signed, params: { id: 1, token: "token" }
+          }.to raise_exception(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context "when the signed token is missing" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+
+        it "redirects to the petition page" do
+          get :signed, params: { id: signature.id }
+          expect(response).to redirect_to("/petitions/#{petition.id}")
+        end
+      end
+
+      context "when the signature is fraudulent" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:signature) { FactoryBot.create(:fraudulent_signature, petition: petition) }
+
+        it "doesn't raise an ActiveRecord::RecordNotFound exception" do
+          expect {
+            get :signed, params: { id: signature.id, token: signature.perishable_token }
+          }.not_to raise_error
+        end
+      end
+
+      context "when the signature is invalidated" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:signature) { FactoryBot.create(:invalidated_signature, petition: petition) }
+
+        it "doesn't raise an ActiveRecord::RecordNotFound exception" do
+          expect {
+            get :signed, params: { id: signature.id }
+          }.not_to raise_error
+        end
+      end
+
+      %w[pending validated sponsored flagged hidden stopped].each do |state|
+        context "when the petition is #{state}" do
+          let(:petition) { FactoryBot.create(:"#{state}_petition") }
+          let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+
+          it "raises an ActiveRecord::RecordNotFound exception" do
+            expect {
+              get :signed, params: { id: signature.id }
+            }.to raise_exception(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+
+      context "when the petition was rejected" do
+        let(:petition) { FactoryBot.create(:rejected_petition) }
+        let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+
+        before do
+          get :signed, params: { id: signature.id }
+        end
+
+        it "assigns the @signature instance variable" do
+          expect(assigns[:signature]).to eq(signature)
         end
 
         it "assigns the @petition instance variable" do
@@ -280,627 +865,32 @@ RSpec.describe SignaturesController, type: :controller do
           expect(response).to redirect_to("/petitions/#{petition.id}")
         end
       end
-    end
 
-    context "when the petition is open" do
-      let(:petition) { FactoryBot.create(:open_petition) }
-      let(:current_time) { Time.utc(2019, 4, 18, 6, 1, 0) }
-
-      around do |example|
-        travel_to(current_time) { example.run }
-      end
-
-      context "and the signature is not a duplicate" do
-        before do
-          cookies.encrypted["wYonHKjTeW7mtTusqDva"] = "2019-04-18T06:00:00Z"
-
-          session[:form_requests] = {
-            "#{petition.id}" => {
-              "form_token" => "wYonHKjTeW7mtTusqDva",
-              "form_requested_at" => "2019-04-18T06:00:00Z"
-            }
-          }
-
-          perform_enqueued_jobs {
-            post :create, params: { petition_id: petition.id, signature: params }
-          }
-        end
-
-        it "assigns the @petition instance variable" do
-          expect(assigns[:petition]).to eq(petition)
-        end
-
-        it "assigns the @signature instance variable with a saved signature" do
-          expect(assigns[:signature]).to be_persisted
-        end
-
-        it "sets the signature's params" do
-          expect(assigns[:signature].name).to eq("Ted Berry")
-          expect(assigns[:signature].email).to eq("ted@example.com")
-          expect(assigns[:signature].uk_citizenship).to eq("1")
-          expect(assigns[:signature].postcode).to eq("SW1A1AA")
-          expect(assigns[:signature].location_code).to eq("GB")
-          expect(assigns[:signature].form_token).to eq("wYonHKjTeW7mtTusqDva")
-          expect(assigns[:signature].form_requested_at).to eq("2019-04-18T06:00:00Z".in_time_zone)
-          expect(assigns[:signature].image_loaded_at).to eq("2019-04-18T06:00:00Z".in_time_zone)
-        end
-
-        it "records the IP address on the signature" do
-          expect(assigns[:signature].ip_address).to eq("0.0.0.0")
-        end
-
-        it "sends a confirmation email" do
-          expect(last_email_sent).to deliver_to("ted@example.com")
-          expect(last_email_sent).to have_subject("Please confirm your email address")
-        end
-
-        it "redirects to the thank you page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}/signatures/thank-you")
-        end
-
-        it "deletes the form request details" do
-          expect(response.cookies).to have_key("wYonHKjTeW7mtTusqDva")
-          expect(response.cookies["wYonHKjTeW7mtTusqDva"]).to be_nil
-          expect(session[:form_requests]["#{petition.id}"]).to be_nil
-        end
-
-        context "and the params are invalid" do
-          let(:params) do
-            {
-              name: "Ted Berry",
-              email: "",
-              uk_citizenship: "1",
-              postcode: "SW1A 1AA",
-              location_code: "GB"
-            }
-          end
-
-          it "renders the signatures/new template" do
-            expect(response).to render_template("signatures/new")
-          end
-        end
-      end
-
-      context "and the signature is a pending duplicate" do
-        let!(:signature) { FactoryBot.create(:pending_signature, params.merge(petition: petition)) }
-
-        before do
-          perform_enqueued_jobs {
-            post :create, params: { petition_id: petition.id, signature: params }
-          }
-        end
-
-        it "assigns the @petition instance variable" do
-          expect(assigns[:petition]).to eq(petition)
-        end
-
-        it "assigns the @signature instance variable to the original signature" do
-          expect(assigns[:signature]).to eq(signature)
-        end
-
-        it "re-sends the confirmation email" do
-          expect(last_email_sent).to deliver_to("ted@example.com")
-          expect(last_email_sent).to have_subject("Please confirm your email address")
-        end
-
-        it "redirects to the thank you page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}/signatures/thank-you")
-        end
-      end
-
-      context "and the signature is a pending duplicate alias" do
-        let!(:signature) { FactoryBot.create(:pending_signature, params.merge(petition: petition)) }
-
-        before do
-          allow(Site).to receive(:disable_plus_address_check?).and_return(true)
-
-          perform_enqueued_jobs {
-            post :create, params: { petition_id: petition.id, signature: params.merge(email: "ted+petitions@example.com") }
-          }
-        end
-
-        it "assigns the @petition instance variable" do
-          expect(assigns[:petition]).to eq(petition)
-        end
-
-        it "assigns the @signature instance variable to the original signature" do
-          expect(assigns[:signature]).to eq(signature)
-        end
-
-        it "re-sends the confirmation email" do
-          expect(last_email_sent).to deliver_to("ted@example.com")
-          expect(last_email_sent).to have_subject("Please confirm your email address")
-        end
-
-        it "redirects to the thank you page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}/signatures/thank-you")
-        end
-      end
-
-      context "and the signature is a validated duplicate" do
-        let!(:signature) { FactoryBot.create(:validated_signature, params.merge(petition: petition)) }
-
-        before do
-          perform_enqueued_jobs {
-            post :create, params: { petition_id: petition.id, signature: params }
-          }
-        end
-
-        it "assigns the @petition instance variable" do
-          expect(assigns[:petition]).to eq(petition)
-        end
-
-        it "assigns the @signature instance variable to the original signature" do
-          expect(assigns[:signature]).to eq(signature)
-        end
-
-        it "sends a duplicate signature email" do
-          expect(last_email_sent).to deliver_to("ted@example.com")
-          expect(last_email_sent).to have_subject("Duplicate signature of petition")
-        end
-
-        it "redirects to the thank you page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}/signatures/thank-you")
-        end
-      end
-
-      context "and the signature is a validated duplicate alias" do
-        let!(:signature) { FactoryBot.create(:validated_signature, params.merge(petition: petition)) }
-
-        before do
-          allow(Site).to receive(:disable_plus_address_check?).and_return(true)
-
-          perform_enqueued_jobs {
-            post :create, params: { petition_id: petition.id, signature: params.merge(email: "ted+petitions@example.com") }
-          }
-        end
-
-        it "assigns the @petition instance variable" do
-          expect(assigns[:petition]).to eq(petition)
-        end
-
-        it "assigns the @signature instance variable to the original signature" do
-          expect(assigns[:signature]).to eq(signature)
-        end
-
-        it "sends a duplicate signature email" do
-          expect(last_email_sent).to deliver_to("ted@example.com")
-          expect(last_email_sent).to have_subject("Duplicate signature of petition")
-        end
-
-        it "redirects to the thank you page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}/signatures/thank-you")
-        end
-      end
-    end
-  end
-
-  describe "GET /petitions/:petition_id/signatures/thank-you" do
-    context "when the petition doesn't exist" do
-      it "raises an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :thank_you, params: { petition_id: 1 }
-        }.to raise_exception(ActiveRecord::RecordNotFound)
-      end
-    end
-
-    %w[pending validated sponsored flagged hidden stopped].each do |state|
-      context "when the petition is #{state}" do
-        let(:petition) { FactoryBot.create(:"#{state}_petition") }
-
-        it "raises an ActiveRecord::RecordNotFound exception" do
-          expect {
-            get :thank_you, params: { petition_id: petition.id }
-          }.to raise_exception(ActiveRecord::RecordNotFound)
-        end
-      end
-    end
-
-    context "when the petition was rejected" do
-      let(:petition) { FactoryBot.create(:rejected_petition) }
-
-      before do
-        get :thank_you, params: { petition_id: petition.id }
-      end
-
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
-      end
-
-      it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been rejected")
-      end
-
-      it "redirects to the petition page" do
-        expect(response).to redirect_to("/petitions/#{petition.id}")
-      end
-    end
-
-    context "when the petition was closed more than 24 hours ago" do
-      let(:petition) { FactoryBot.create(:closed_petition, closed_at: 36.hours.ago) }
-      let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
-
-      before do
-        get :thank_you, params: { petition_id: petition.id }
-      end
-
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
-      end
-
-      it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
-      end
-
-      it "redirects to the petition page" do
-        expect(response).to redirect_to("/petitions/#{petition.id}")
-      end
-    end
-
-    context "when the petition was closed less than 24 hours ago" do
-      let(:petition) { FactoryBot.create(:closed_petition, closed_at: 12.hours.ago) }
-      let(:signature) { FactoryBot.create(:validated_signature, :just_signed, petition: petition) }
-
-      before do
-        get :thank_you, params: { petition_id: petition.id }
-      end
-
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
-      end
-
-      it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
-      end
-
-      it "redirects to the petition page" do
-        expect(response).to redirect_to("/petitions/#{petition.id}")
-      end
-    end
-
-    context "when the petition is open" do
-      let(:petition) { FactoryBot.create(:open_petition) }
-      let(:signature) { FactoryBot.create(:validated_signature, :just_signed, petition: petition) }
-
-      before do
-        get :thank_you, params: { petition_id: petition.id }
-      end
-
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
-      end
-
-      it "renders the signatures/thank_you template" do
-        expect(response).to render_template("signatures/thank_you")
-      end
-    end
-  end
-
-  describe "GET /signatures/:id/verify" do
-    context "when the signature doesn't exist" do
-      it "raises an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :verify, params: { id: 1, token: "token" }
-        }.to raise_exception(ActiveRecord::RecordNotFound)
-      end
-    end
-
-    context "when the signature token is invalid" do
-      let(:petition) { FactoryBot.create(:open_petition) }
-      let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
-
-      it "raises an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :verify, params: { id: signature.id, token: "token" }
-        }.to raise_error(ActiveRecord::RecordNotFound)
-      end
-    end
-
-    context "when the signature is fraudulent" do
-      let(:petition) { FactoryBot.create(:open_petition) }
-      let(:signature) { FactoryBot.create(:fraudulent_signature, petition: petition) }
-
-      it "doesn't raise an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :verify, params: { id: signature.id, token: signature.perishable_token }
-        }.not_to raise_error
-      end
-    end
-
-    context "when the signature is invalidated" do
-      let(:petition) { FactoryBot.create(:open_petition) }
-      let(:signature) { FactoryBot.create(:invalidated_signature, petition: petition) }
-
-      it "doesn't raise an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :verify, params: { id: signature.id, token: signature.perishable_token }
-        }.not_to raise_error
-      end
-    end
-
-    %w[pending validated sponsored flagged hidden stopped].each do |state|
-      context "when the petition is #{state}" do
-        let(:petition) { FactoryBot.create(:"#{state}_petition") }
-        let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
-
-        it "raises an ActiveRecord::RecordNotFound exception" do
-          expect {
-            get :verify, params: { id: signature.id, token: signature.perishable_token }
-          }.to raise_exception(ActiveRecord::RecordNotFound)
-        end
-      end
-    end
-
-    context "when the petition was rejected" do
-      let(:petition) { FactoryBot.create(:rejected_petition) }
-      let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
-
-      before do
-        get :verify, params: { id: signature.id, token: signature.perishable_token }
-      end
-
-      it "assigns the @signature instance variable" do
-        expect(assigns[:signature]).to eq(signature)
-      end
-
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
-      end
-
-      it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been rejected")
-      end
-
-      it "redirects to the petition page" do
-        expect(response).to redirect_to("/petitions/#{petition.id}")
-      end
-    end
-
-    context "when the petition was closed more than 24 hours ago" do
-      let(:petition) { FactoryBot.create(:closed_petition, closed_at: 36.hours.ago) }
-      let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
-
-      before do
-        get :verify, params: { id: signature.id, token: signature.perishable_token }
-      end
-
-      it "assigns the @signature instance variable" do
-        expect(assigns[:signature]).to eq(signature)
-      end
-
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
-      end
-
-      it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
-      end
-
-      it "redirects to the petition page" do
-        expect(response).to redirect_to("/petitions/#{petition.id}")
-      end
-    end
-
-    context "when the petition was closed less than 24 hours ago" do
-      let(:petition) { FactoryBot.create(:closed_petition, closed_at: 12.hours.ago) }
-      let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
-
-      before do
-        get :verify, params: { id: signature.id, token: signature.perishable_token }
-      end
-
-      it "assigns the @signature instance variable" do
-        expect(assigns[:signature]).to eq(signature)
-      end
-
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
-      end
-
-      it "validates the signature" do
-        expect(assigns[:signature]).to be_validated
-      end
-
-      it "records the constituency id on the signature" do
-        expect(assigns[:signature].constituency_id).to eq("3415")
-      end
-
-      it "records the ip address on the signature" do
-        expect(assigns[:signature].validated_ip).to eq("0.0.0.0")
-      end
-
-      it "saves the signed token in the session" do
-        expect(session[:signed_tokens]).to eq({ signature.id.to_s => signature.signed_token })
-      end
-
-      it "redirects to the signed signature page" do
-        expect(response).to redirect_to("/signatures/#{signature.id}/signed")
-      end
-    end
-
-    context "when the petition is open" do
-      let(:petition) { FactoryBot.create(:open_petition) }
-      let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
-      let(:other_petition) { FactoryBot.create(:open_petition) }
-      let(:other_signature) { FactoryBot.create(:validated_signature, petition: other_petition) }
-
-      before do
-        session[:signed_tokens] = {
-          other_signature.id.to_s => other_signature.signed_token
-        }
-
-        get :verify, params: { id: signature.id, token: signature.perishable_token }
-      end
-
-      it "assigns the @signature instance variable" do
-        expect(assigns[:signature]).to eq(signature)
-      end
-
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
-      end
-
-      it "validates the signature" do
-        expect(assigns[:signature]).to be_validated
-      end
-
-      it "records the constituency id on the signature" do
-        expect(assigns[:signature].constituency_id).to eq("3415")
-      end
-
-      it "records the ip address on the signature" do
-        expect(assigns[:signature].validated_ip).to eq("0.0.0.0")
-      end
-
-      it "deletes old signed tokens" do
-        expect(session[:signed_tokens]).not_to have_key(other_signature.id.to_s)
-      end
-
-      it "saves the signed token in the session" do
-        expect(session[:signed_tokens]).to eq({ signature.id.to_s => signature.signed_token })
-      end
-
-      it "redirects to the signed signature page" do
-        expect(response).to redirect_to("/signatures/#{signature.id}/signed")
-      end
-
-      context "and the signature has already been validated" do
+      context "when the petition was closed more than 24 hours ago" do
+        let(:petition) { FactoryBot.create(:closed_petition, closed_at: 36.hours.ago) }
         let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
 
-        it "doesn't set the flash :notice message" do
-          expect(flash[:notice]).to be_nil
-        end
-      end
-    end
-  end
-
-  describe "GET /signatures/:id/signed" do
-    context "when the signature doesn't exist" do
-      it "raises an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :signed, params: { id: 1, token: "token" }
-        }.to raise_exception(ActiveRecord::RecordNotFound)
-      end
-    end
-
-    context "when the signed token is missing" do
-      let(:petition) { FactoryBot.create(:open_petition) }
-      let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
-
-      it "redirects to the petition page" do
-        get :signed, params: { id: signature.id }
-        expect(response).to redirect_to("/petitions/#{petition.id}")
-      end
-    end
-
-    context "when the signature is fraudulent" do
-      let(:petition) { FactoryBot.create(:open_petition) }
-      let(:signature) { FactoryBot.create(:fraudulent_signature, petition: petition) }
-
-      it "doesn't raise an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :signed, params: { id: signature.id, token: signature.perishable_token }
-        }.not_to raise_error
-      end
-    end
-
-    context "when the signature is invalidated" do
-      let(:petition) { FactoryBot.create(:open_petition) }
-      let(:signature) { FactoryBot.create(:invalidated_signature, petition: petition) }
-
-      it "doesn't raise an ActiveRecord::RecordNotFound exception" do
-        expect {
+        before do
           get :signed, params: { id: signature.id }
-        }.not_to raise_error
-      end
-    end
+        end
 
-    %w[pending validated sponsored flagged hidden stopped].each do |state|
-      context "when the petition is #{state}" do
-        let(:petition) { FactoryBot.create(:"#{state}_petition") }
-        let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+        it "assigns the @signature instance variable" do
+          expect(assigns[:signature]).to eq(signature)
+        end
 
-        it "raises an ActiveRecord::RecordNotFound exception" do
-          expect {
-            get :signed, params: { id: signature.id }
-          }.to raise_exception(ActiveRecord::RecordNotFound)
+        it "assigns the @petition instance variable" do
+          expect(assigns[:petition]).to eq(petition)
+        end
+
+        it "redirects to the petition page" do
+          expect(response).to redirect_to("/petitions/#{petition.id}")
         end
       end
-    end
 
-    context "when the petition was rejected" do
-      let(:petition) { FactoryBot.create(:rejected_petition) }
-      let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+      context "when the petition was closed less than 24 hours ago" do
+        let(:petition) { FactoryBot.create(:closed_petition, closed_at: 12.hours.ago) }
+        let(:signature) { FactoryBot.create(:validated_signature, :just_signed, petition: petition) }
 
-      before do
-        get :signed, params: { id: signature.id }
-      end
-
-      it "assigns the @signature instance variable" do
-        expect(assigns[:signature]).to eq(signature)
-      end
-
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
-      end
-
-      it "redirects to the petition page" do
-        expect(response).to redirect_to("/petitions/#{petition.id}")
-      end
-    end
-
-    context "when the petition was closed more than 24 hours ago" do
-      let(:petition) { FactoryBot.create(:closed_petition, closed_at: 36.hours.ago) }
-      let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
-
-      before do
-        get :signed, params: { id: signature.id }
-      end
-
-      it "assigns the @signature instance variable" do
-        expect(assigns[:signature]).to eq(signature)
-      end
-
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
-      end
-
-      it "redirects to the petition page" do
-        expect(response).to redirect_to("/petitions/#{petition.id}")
-      end
-    end
-
-    context "when the petition was closed less than 24 hours ago" do
-      let(:petition) { FactoryBot.create(:closed_petition, closed_at: 12.hours.ago) }
-      let(:signature) { FactoryBot.create(:validated_signature, :just_signed, petition: petition) }
-
-      before do
-        session[:signed_tokens] = { signature.id.to_s => signature.signed_token }
-        get :signed, params: { id: signature.id }
-      end
-
-      it "assigns the @signature instance variable" do
-        expect(assigns[:signature]).to eq(signature)
-      end
-
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
-      end
-
-      it "marks the signature has having seen the confirmation page" do
-        expect(assigns[:signature].seen_signed_confirmation_page).to eq(true)
-      end
-
-      it "renders the signatures/signed template" do
-        expect(response).to render_template("signatures/signed")
-      end
-    end
-
-    context "when the petition is open" do
-      let(:petition) { FactoryBot.create(:open_petition) }
-      let(:signature) { FactoryBot.create(:validated_signature, :just_signed, petition: petition) }
-
-      context "when the signature has been validated" do
         before do
           session[:signed_tokens] = { signature.id.to_s => signature.signed_token }
           get :signed, params: { id: signature.id }
@@ -921,186 +911,214 @@ RSpec.describe SignaturesController, type: :controller do
         it "renders the signatures/signed template" do
           expect(response).to render_template("signatures/signed")
         end
+      end
 
-        it "deletes the signed token from the session" do
-          expect(session[:signed_tokens]).to be_empty
+      context "when the petition is open" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:signature) { FactoryBot.create(:validated_signature, :just_signed, petition: petition) }
+
+        context "when the signature has been validated" do
+          before do
+            session[:signed_tokens] = { signature.id.to_s => signature.signed_token }
+            get :signed, params: { id: signature.id }
+          end
+
+          it "assigns the @signature instance variable" do
+            expect(assigns[:signature]).to eq(signature)
+          end
+
+          it "assigns the @petition instance variable" do
+            expect(assigns[:petition]).to eq(petition)
+          end
+
+          it "marks the signature has having seen the confirmation page" do
+            expect(assigns[:signature].seen_signed_confirmation_page).to eq(true)
+          end
+
+          it "renders the signatures/signed template" do
+            expect(response).to render_template("signatures/signed")
+          end
+
+          it "deletes the signed token from the session" do
+            expect(session[:signed_tokens]).to be_empty
+          end
+
+          context "and the signature has already seen the confirmation page" do
+            let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
+
+            it "doesn't redirect to the petition page" do
+              expect(response).not_to redirect_to("/petitions/#{petition.id}")
+            end
+          end
         end
 
-        context "and the signature has already seen the confirmation page" do
-          let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
+        context "when the signature has not been validated" do
+          let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
 
-          it "doesn't redirect to the petition page" do
-            expect(response).not_to redirect_to("/petitions/#{petition.id}")
+          before do
+            get :signed, params: { id: signature.id }
+          end
+
+          it "redirects to the petition page" do
+            expect(response).to redirect_to("/petitions/#{petition.id}")
           end
         end
       end
+    end
 
-      context "when the signature has not been validated" do
-        let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
-
-        before do
-          get :signed, params: { id: signature.id }
-        end
-
-        it "redirects to the petition page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}")
+    describe "GET /signatures/:id/unsubscribe" do
+      context "when the signature doesn't exist" do
+        it "raises an ActiveRecord::RecordNotFound exception" do
+          expect {
+            get :unsubscribe, params: { id: 1, token: "token" }
+          }.to raise_exception(ActiveRecord::RecordNotFound)
         end
       end
-    end
-  end
 
-  describe "GET /signatures/:id/unsubscribe" do
-    context "when the signature doesn't exist" do
-      it "raises an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :unsubscribe, params: { id: 1, token: "token" }
-        }.to raise_exception(ActiveRecord::RecordNotFound)
-      end
-    end
-
-    context "when the signature token is invalid" do
-      let(:petition) { FactoryBot.create(:open_petition) }
-      let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
-
-      it "raises an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :unsubscribe, params: { id: signature.id, token: "token" }
-        }.to raise_error(ActiveRecord::RecordNotFound)
-      end
-    end
-
-    context "when the signature is fraudulent" do
-      let(:petition) { FactoryBot.create(:open_petition) }
-      let(:signature) { FactoryBot.create(:fraudulent_signature, petition: petition) }
-
-      it "doesn't raise an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :unsubscribe, params: { id: signature.id, token: signature.unsubscribe_token }
-        }.not_to raise_error
-      end
-    end
-
-    context "when the signature is invalidated" do
-      let(:petition) { FactoryBot.create(:open_petition) }
-      let(:signature) { FactoryBot.create(:invalidated_signature, petition: petition) }
-
-      it "doesn't raise an ActiveRecord::RecordNotFound exception" do
-        expect {
-          get :unsubscribe, params: { id: signature.id, token: signature.unsubscribe_token }
-        }.not_to raise_error
-      end
-    end
-
-    %w[pending validated sponsored flagged hidden stopped].each do |state|
-      context "when the petition is #{state}" do
-        let(:petition) { FactoryBot.create(:"#{state}_petition") }
+      context "when the signature token is invalid" do
+        let(:petition) { FactoryBot.create(:open_petition) }
         let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
 
         it "raises an ActiveRecord::RecordNotFound exception" do
           expect {
-            get :unsubscribe, params: { id: signature.id, token: signature.unsubscribe_token }
-          }.to raise_exception(ActiveRecord::RecordNotFound)
+            get :unsubscribe, params: { id: signature.id, token: "token" }
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
-    end
 
-    context "when the petition was rejected" do
-      let(:petition) { FactoryBot.create(:rejected_petition) }
-      let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
+      context "when the signature is fraudulent" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:signature) { FactoryBot.create(:fraudulent_signature, petition: petition) }
 
-      before do
-        get :unsubscribe, params: { id: signature.id, token: signature.unsubscribe_token }
+        it "doesn't raise an ActiveRecord::RecordNotFound exception" do
+          expect {
+            get :unsubscribe, params: { id: signature.id, token: signature.unsubscribe_token }
+          }.not_to raise_error
+        end
       end
 
-      it "assigns the @signature instance variable" do
-        expect(assigns[:signature]).to eq(signature)
+      context "when the signature is invalidated" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:signature) { FactoryBot.create(:invalidated_signature, petition: petition) }
+
+        it "doesn't raise an ActiveRecord::RecordNotFound exception" do
+          expect {
+            get :unsubscribe, params: { id: signature.id, token: signature.unsubscribe_token }
+          }.not_to raise_error
+        end
       end
 
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
+      %w[pending validated sponsored flagged hidden stopped].each do |state|
+        context "when the petition is #{state}" do
+          let(:petition) { FactoryBot.create(:"#{state}_petition") }
+          let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+
+          it "raises an ActiveRecord::RecordNotFound exception" do
+            expect {
+              get :unsubscribe, params: { id: signature.id, token: signature.unsubscribe_token }
+            }.to raise_exception(ActiveRecord::RecordNotFound)
+          end
+        end
       end
 
-      it "unsubscribes from email updates" do
-        expect(assigns[:signature].notify_by_email).to eq(false)
+      context "when the petition was rejected" do
+        let(:petition) { FactoryBot.create(:rejected_petition) }
+        let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
+
+        before do
+          get :unsubscribe, params: { id: signature.id, token: signature.unsubscribe_token }
+        end
+
+        it "assigns the @signature instance variable" do
+          expect(assigns[:signature]).to eq(signature)
+        end
+
+        it "assigns the @petition instance variable" do
+          expect(assigns[:petition]).to eq(petition)
+        end
+
+        it "unsubscribes from email updates" do
+          expect(assigns[:signature].notify_by_email).to eq(false)
+        end
+
+        it "renders the signatures/unsubscribe template" do
+          expect(response).to render_template("signatures/unsubscribe")
+        end
       end
 
-      it "renders the signatures/unsubscribe template" do
-        expect(response).to render_template("signatures/unsubscribe")
-      end
-    end
+      context "when the petition was closed more than 24 hours ago" do
+        let(:petition) { FactoryBot.create(:closed_petition, closed_at: 36.hours.ago) }
+        let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
 
-    context "when the petition was closed more than 24 hours ago" do
-      let(:petition) { FactoryBot.create(:closed_petition, closed_at: 36.hours.ago) }
-      let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
+        before do
+          get :unsubscribe, params: { id: signature.id, token: signature.unsubscribe_token }
+        end
 
-      before do
-        get :unsubscribe, params: { id: signature.id, token: signature.unsubscribe_token }
-      end
+        it "assigns the @signature instance variable" do
+          expect(assigns[:signature]).to eq(signature)
+        end
 
-      it "assigns the @signature instance variable" do
-        expect(assigns[:signature]).to eq(signature)
-      end
+        it "assigns the @petition instance variable" do
+          expect(assigns[:petition]).to eq(petition)
+        end
 
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
-      end
+        it "unsubscribes from email updates" do
+          expect(assigns[:signature].notify_by_email).to eq(false)
+        end
 
-      it "unsubscribes from email updates" do
-        expect(assigns[:signature].notify_by_email).to eq(false)
-      end
-
-      it "renders the signatures/unsubscribe template" do
-        expect(response).to render_template("signatures/unsubscribe")
-      end
-    end
-
-    context "when the petition was closed less than 24 hours ago" do
-      let(:petition) { FactoryBot.create(:closed_petition, closed_at: 12.hours.ago) }
-      let(:signature) { FactoryBot.create(:validated_signature, :just_signed, petition: petition) }
-
-      before do
-        get :unsubscribe, params: { id: signature.id, token: signature.unsubscribe_token }
+        it "renders the signatures/unsubscribe template" do
+          expect(response).to render_template("signatures/unsubscribe")
+        end
       end
 
-      it "assigns the @signature instance variable" do
-        expect(assigns[:signature]).to eq(signature)
+      context "when the petition was closed less than 24 hours ago" do
+        let(:petition) { FactoryBot.create(:closed_petition, closed_at: 12.hours.ago) }
+        let(:signature) { FactoryBot.create(:validated_signature, :just_signed, petition: petition) }
+
+        before do
+          get :unsubscribe, params: { id: signature.id, token: signature.unsubscribe_token }
+        end
+
+        it "assigns the @signature instance variable" do
+          expect(assigns[:signature]).to eq(signature)
+        end
+
+        it "assigns the @petition instance variable" do
+          expect(assigns[:petition]).to eq(petition)
+        end
+
+        it "unsubscribes from email updates" do
+          expect(assigns[:signature].notify_by_email).to eq(false)
+        end
+
+        it "renders the signatures/unsubscribe template" do
+          expect(response).to render_template("signatures/unsubscribe")
+        end
       end
 
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
-      end
+      context "when the petition is open" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+        let(:signature) { FactoryBot.create(:validated_signature, :just_signed, petition: petition) }
 
-      it "unsubscribes from email updates" do
-        expect(assigns[:signature].notify_by_email).to eq(false)
-      end
+        before do
+          get :unsubscribe, params: { id: signature.id, token: signature.unsubscribe_token }
+        end
 
-      it "renders the signatures/unsubscribe template" do
-        expect(response).to render_template("signatures/unsubscribe")
-      end
-    end
+        it "assigns the @signature instance variable" do
+          expect(assigns[:signature]).to eq(signature)
+        end
 
-    context "when the petition is open" do
-      let(:petition) { FactoryBot.create(:open_petition) }
-      let(:signature) { FactoryBot.create(:validated_signature, :just_signed, petition: petition) }
+        it "assigns the @petition instance variable" do
+          expect(assigns[:petition]).to eq(petition)
+        end
 
-      before do
-        get :unsubscribe, params: { id: signature.id, token: signature.unsubscribe_token }
-      end
+        it "unsubscribes from email updates" do
+          expect(assigns[:signature].notify_by_email).to eq(false)
+        end
 
-      it "assigns the @signature instance variable" do
-        expect(assigns[:signature]).to eq(signature)
-      end
-
-      it "assigns the @petition instance variable" do
-        expect(assigns[:petition]).to eq(petition)
-      end
-
-      it "unsubscribes from email updates" do
-        expect(assigns[:signature].notify_by_email).to eq(false)
-      end
-
-      it "renders the signatures/unsubscribe template" do
-        expect(response).to render_template("signatures/unsubscribe")
+        it "renders the signatures/unsubscribe template" do
+          expect(response).to render_template("signatures/unsubscribe")
+        end
       end
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,10 @@
 require 'factory_bot'
 
 FactoryBot.define do
+  factory :user do
+    sequence(:email) {|n| "user#{n}@example.com"}
+    sequence(:username) {|n| "examplename#{n}"}
+  end
   factory :admin_user do
     sequence(:email) {|n| "admin#{n}@example.com" }
     password              { "Letmein1!" }


### PR DESCRIPTION
Adds authorization for petition and signatures creation. 
Removed redundant specs (testing removed validations / attributes)
changed spec.rb files have the authorization specs in the beginning, the rest are not important changes (wrapped tests inside a "With logged in user" -context and removing a couple of references to removed attributes)