### PR TITLE
Bug/petition creator signature count

### DIFF
--- a/app/models/petition_creator.rb
+++ b/app/models/petition_creator.rb
@@ -56,6 +56,7 @@ class PetitionCreator
           c.notify_by_email = notify_by_email
           c.ip_address = request.remote_ip
           c.state = Signature::VALIDATED_STATE
+          c.validated_at = Time.current
         end
       end
 

--- a/spec/models/petition_creator_spec.rb
+++ b/spec/models/petition_creator_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+require_relative 'taggable_examples'
+
+RSpec.describe PetitionCreator, type: :model do
+  context "methods" do
+    context "save" do
+      let(:params) do
+        {
+          action: SecureRandom.uuid,
+          background: "Limit temperature rise at two degrees",
+          additional_details: "Global warming is upon us",
+          name: "John Mcenroe", email: "john@example.com",
+          postcode: "SE3 4LL", location_code: "GB",
+          uk_citizenship: "1"
+        }
+      end
+
+      let(:mock_request) do
+        double(remote_ip: "0.0.0.0")
+      end
+
+      it "creates a valid signature for the creator" do
+        petition_creator = described_class.new(ActionController::Parameters.new({ petition_creator: params, stage: "replay_email" }), mock_request)
+        petition_creator.save
+
+        # This is a workaround to test against the correct petition since PetitionCreator doesn't actually return the created petition.
+        # Because of this, we use a generated UUID as the action in order to retrieve the correct petition from db without knowing it's id
+        # getting latest petition won't always work in case we run tests in parallel (or it might not work).
+        petition = Petition.find_by_action(params[:action])
+        expect(petition.signature_count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Petition signatures_count was incorrectly 0 after creation because signature created for the creator didn't have validated_at timestamp.