### PR TITLE
turned on email notifications on by default for petition creators

### DIFF
--- a/app/models/petition_creator.rb
+++ b/app/models/petition_creator.rb
@@ -119,7 +119,7 @@ class PetitionCreator
   end
 
   def notify_by_email
-    petition_creator_params[:notify_by_email] || "0"
+    petition_creator_params[:notify_by_email] || "1"
   end
 
   private


### PR DESCRIPTION
Issue seemed to be that the petition creator never had notify_by_email set as true - there is no way to set it on during the petition creation and it was off by default.